### PR TITLE
fix: change pageToken request type

### DIFF
--- a/data_sharing/routers/delta_sharing.py
+++ b/data_sharing/routers/delta_sharing.py
@@ -6,7 +6,7 @@ import orjson
 from fastapi import APIRouter, Depends, Header, Path, Query, Security
 from fastapi.requests import Request
 from fastapi.responses import ORJSONResponse, Response
-from pydantic import BaseModel
+from pydantic import BaseModel, conint
 
 from data_sharing.annotations.delta_sharing import (
     delta_sharing_capabilities_header_description,
@@ -87,7 +87,9 @@ async def forward_sharing_request(
 async def list_shares(
     request: Request,
     response: Response,
-    maxResults: Annotated[int, Query(description=max_results_description)] = None,
+    maxResults: Annotated[
+        conint(ge=0), Query(description=max_results_description)
+    ] = None,
     pageToken: Annotated[str, Query(description=page_token_description)] = None,
 ):
     query_params = dict(maxResults=maxResults, pageToken=pageToken)
@@ -106,7 +108,9 @@ async def get_share(
     share_name: Annotated[str, Path(description=share_name_description)],
     request: Request,
     response: Response,
-    maxResults: Annotated[int, Query(description=max_results_description)] = None,
+    maxResults: Annotated[
+        conint(ge=0), Query(description=max_results_description)
+    ] = None,
     pageToken: Annotated[str, Query(description=page_token_description)] = None,
 ):
     query_params = dict(maxResults=maxResults, pageToken=pageToken)
@@ -126,7 +130,9 @@ async def list_schemas(
     share_name: Annotated[str, Path(description=share_name_description)],
     request: Request,
     response: Response,
-    maxResults: Annotated[int, Query(description=max_results_description)] = None,
+    maxResults: Annotated[
+        conint(ge=0), Query(description=max_results_description)
+    ] = None,
     pageToken: Annotated[str, Query(description=page_token_description)] = None,
 ):
     query_params = dict(maxResults=maxResults, pageToken=pageToken)
@@ -147,7 +153,9 @@ async def list_tables(
     schema_name: Annotated[str, Path(description=schema_name_description)],
     request: Request,
     response: Response,
-    maxResults: Annotated[int, Query(description=max_results_description)] = None,
+    maxResults: Annotated[
+        conint(ge=0), Query(description=max_results_description)
+    ] = None,
     pageToken: Annotated[str, Query(description=page_token_description)] = None,
     current_user: ApiKey = Depends(get_current_user),
 ):
@@ -176,7 +184,9 @@ async def list_tables_in_share(
     share_name: Annotated[str, Path(description=share_name_description)],
     request: Request,
     response: Response,
-    maxResults: Annotated[int, Query(description=max_results_description)] = None,
+    maxResults: Annotated[
+        conint(ge=0), Query(description=max_results_description)
+    ] = None,
     pageToken: Annotated[str, Query(description=page_token_description)] = None,
     current_user: ApiKey = Depends(get_current_user),
 ):

--- a/data_sharing/schemas/delta.py
+++ b/data_sharing/schemas/delta.py
@@ -83,10 +83,11 @@ class RemoveWrapper(BaseModel):
 
 class CDC(BaseModel):
     path: str
+    pathAsUri: str = Field(None)
     partitionValues: dict[str, str]
     size: conint(ge=0)
     dataChange: bool
-    tags: dict[str, str]
+    tags: dict[str, str] = Field(None)
 
 
 class CDCWrapper(BaseModel):

--- a/data_sharing/schemas/delta_sharing.py
+++ b/data_sharing/schemas/delta_sharing.py
@@ -13,7 +13,7 @@ T = TypeVar("T")
 
 
 class Pagination(BaseModel, Generic[T]):
-    items: list[T]
+    items: list[T] = Field([])
     nextPageToken: str = Field("")
 
 

--- a/data_sharing/utils/header.py
+++ b/data_sharing/utils/header.py
@@ -2,7 +2,7 @@ def parse_capabilities_header(header: str | None) -> dict[str, str]:
     if header is None:
         return {}
 
-    splits = [h.strip() for h in header.split(",")]
+    splits = [h.strip() for h in header.split(";")]
     parsed = {}
     for split in splits:
         key, value = split.split("=")


### PR DESCRIPTION
## What type of PR is this?

- `fix`: Commits that fix a bug

## Summary

Change the `pageToken` request parameter from `string` to `int`

## How to test

1. Verify that `pageToken` parameters require a `string` instead of an `int`
![image](https://github.com/unicef/giga-data-sharing/assets/122899250/dae4e49a-f279-42cd-9a86-051718bbda81)

## Link to Jira/Asana/Airtable task (if applicable)

[gdoc link
](https://docs.google.com/spreadsheets/d/19U0daWsFVUN196BFC7EbQFDcw-opKi2JqSAZVbddV8U/edit#gid=2120345002)

![image](https://github.com/unicef/giga-data-sharing/assets/122899250/494276f9-95c2-413f-8c19-a44f2ee8c0bb)

