### PR TITLE
chore: move image to bitnamilegacy

### DIFF
--- a/infra/helm/data-sharing-proxy/templates/deployment.yaml
+++ b/infra/helm/data-sharing-proxy/templates/deployment.yaml
@@ -59,7 +59,7 @@ spec:
             {{- toYaml .Values.resources | nindent 12 }}
       initContainers:
         - name: init-wait-db
-          image: bitnami/postgresql:16.1.0-debian-11-r13
+          image: bitnamilegacy/postgresql:16.1.0-debian-11-r13
           command:
             - /bin/sh
             - -c


### PR DESCRIPTION
## What type of PR is this?

- `chore`: Miscellaneous commits (e.g. modifying `.gitignore`)

## Summary

What does this PR do

Updates bitnami docker image to use bitanamilegacy
